### PR TITLE
Don't use default mapping if already mapped

### DIFF
--- a/plugin/sourcebeautify/sourcebeautify.vim
+++ b/plugin/sourcebeautify/sourcebeautify.vim
@@ -149,4 +149,6 @@ if !exists("*s:beautify")
     endfunction
 endif
 
-nnoremap <silent> <leader>sb :call <SID>beautify()<cr>
+if maparg('<leader>sb', 'n') == ''
+  nnoremap <silent> <leader>sb :call <SID>beautify()<cr>
+endif


### PR DESCRIPTION
Only use mapping if not already used.
